### PR TITLE
feat: Implement win/loss conditions and restart

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -87,6 +87,11 @@ export function moveSnake(gameState) {
 
   gameState.snake.body.unshift(newHead);
 
+  if (checkCollision(gameState)) {
+    gameState.status = GameStatus.GAME_OVER;
+    return;
+  }
+
   if (!eatFood(gameState)) {
     gameState.snake.body.pop();
   }

--- a/src/index.html
+++ b/src/index.html
@@ -12,5 +12,9 @@
   <div id="ui">
     <p>Score: <span id="score">0</span></p>
   </div>
+  <div id="gameOverScreen" style="display: none;">
+    <h2>Game Over!</h2>
+    <button id="restartButton">Restart Game</button>
+  </div>
 </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -12,16 +12,19 @@ import { FRAME_RATE } from './config.js';
 let gameState = createGameState();
 const canvas = document.getElementById('game-canvas');
 
+function restartGame() {
+  gameState = createGameState();
+  gameState.status = GameStatus.PLAYING;
+  gameLoop();
+}
+
 function gameLoop() {
   if (gameState.status === GameStatus.PLAYING) {
     moveSnake(gameState);
-    if (checkCollision(gameState)) {
-      gameState.status = GameStatus.GAME_OVER;
-    }
   }
 
   render(gameState, canvas);
-  updateUI(gameState);
+  updateUI(gameState, restartGame);
 
   setTimeout(gameLoop, 1000 / FRAME_RATE);
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -5,8 +5,19 @@
 /**
  * Updates the UI with the current game state.
  * @param {object} gameState The current game state.
+ * @param {function} onRestart Callback function to restart the game.
  */
-export function updateUI(gameState) {
+export function updateUI(gameState, onRestart) {
   const scoreElement = document.getElementById('score');
   scoreElement.textContent = gameState.score;
+
+  const gameOverScreen = document.getElementById('gameOverScreen');
+  const restartButton = document.getElementById('restartButton');
+
+  if (gameState.status === 'GAME_OVER') {
+    gameOverScreen.style.display = 'flex';
+    restartButton.onclick = onRestart;
+  } else {
+    gameOverScreen.style.display = 'none';
+  }
 }


### PR DESCRIPTION
Closes #7.

This pull request implements the win/loss conditions (eating food, collision with self or boundaries) and introduces the functionality to restart the game.

- **Game Logic (src/game.js):**
  - Modified  to incorporate .
  -  now correctly sets  to  upon collision.
  -  handles score increment and new food generation.
- **UI (src/ui.js, src/main.js, src/index.html):**
  -  now displays a 'Game Over!' message and a 'Restart Game' button when  is .
  -  includes a  function that resets the game state and is passed as a callback to .
  -  has been updated with the 'Game Over' screen and 'Restart Game' button elements.